### PR TITLE
Fix install problem without .git

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
-include AUTHORS
-include ChangeLog
-exclude .gitignore
-exclude .gitreview
-
+include *
+exclude .*
 global-exclude *.pyc


### PR DESCRIPTION
Without folder .git, use "export PBR_VERSION==2014.2&&python setup.py install" to install ironic will cause some problems. Some files such as "ironic/db/sqlalchemy/alembic.ini","ironic/drivers/modules/elilo_efi_pxe_config.template" won't be installed. It will cause that ironic won't work well. These files are under the git version control but cannot be included in MANIFEST.in. So, Without .git, they can not be installed. And I modify this problem by updating MANIFEST.in to include them.
