### PR TITLE
Adding note to address firewall/proxy blocking Git protocol

### DIFF
--- a/doc/source/dev/dev-quickstart.rst
+++ b/doc/source/dev/dev-quickstart.rst
@@ -465,6 +465,17 @@ and uses the ``agent_ipmitool`` driver by default::
     END
 
 .. note::
+    Git protocol requires firewall access to port 9418, which is not a standard port
+    that corporate firewalls always allow. If you are behind a firewall or on a proxy
+    that blocks Git protocol, modify the ``enable_plugin`` line to use ``https://``
+    instead of ``git://`` and add ``GIT_BASE=https://git.openstack.org`` to the credentials::
+
+      GIT_BASE=https://git.openstack.org
+      
+      # Enable Ironic plugin
+      enable_plugin ironic https://git.openstack.org/openstack/ironic
+
+.. note::
     The agent_ssh and pxe_ssh drivers are being deprecated in favor of the
     more production-like agent_ipmitool and pxe_ipmitool drivers. When a
     \*_ipmitool driver is set and IRONIC_IS_HARDWARE variable is false devstack


### PR DESCRIPTION
local.conf file for deploying ironic with devstack uses Git protocol to enable ironic plugin. Git protocol requires access to port 9418 which corporate firewalls commonly block. 

Added a note to the local.conf file informing users who face this problem how to modify the local.conf file to use https:// instead of git:// so ironic plugin will be enabled.

Closes-Bug: #1604243