### PR TITLE
Fix Lenovo UEFI boot loops in Redfish boot interface

### DIFF
--- a/ironic/drivers/modules/agent.py
+++ b/ironic/drivers/modules/agent.py
@@ -790,7 +790,7 @@ class AgentDeploy(CustomAgentDeploy):
             self.prepare_instance_to_boot(task, root_uuid,
                                           efi_sys_uuid, prep_boot_part_uuid)
         else:
-            manager_utils.node_set_boot_device(task, 'disk', persistent=True)
+            set_boot_to_disk(task)
 
         # Remove symbolic link and image when deploy is done.
         deploy_utils.destroy_http_instance_images(task.node)

--- a/ironic/drivers/modules/redfish/boot.py
+++ b/ironic/drivers/modules/redfish/boot.py
@@ -821,6 +821,24 @@ def _select_transport_protocol(task, supported_protocols):
     return TRANSPORT_HTTP
 
 
+def _skip_lenovo_uefi_disk_boot_device(task, device):
+    """Return True if setting disk boot device should be skipped.
+
+    On Lenovo UEFI systems, setting boot to generic HDD via Redfish can
+    bypass the OS UEFI shim and cause boot loops. Rely on UEFI boot order
+    instead. For more information see
+    https://bugs.launchpad.net/ironic/+bug/2053064
+    """
+    if device != boot_devices.DISK:
+        return False
+
+    vendor = task.node.properties.get('vendor')
+    boot_mode = boot_mode_utils.get_boot_mode(task.node)
+    return (task.node.provision_state == states.DEPLOYING
+            and vendor and vendor.lower() == 'lenovo'
+            and boot_mode == 'uefi')
+
+
 class RedfishVirtualMediaBoot(base.BootInterface):
     """Virtual media boot interface over Redfish.
 
@@ -1273,6 +1291,13 @@ class RedfishVirtualMediaBoot(base.BootInterface):
         :raises: InvalidParameterValue if the validation of the
             ManagementInterface fails.
         """
+        if _skip_lenovo_uefi_disk_boot_device(task, device):
+            LOG.debug('Skipping setting boot device to %(device)s for Lenovo '
+                      'UEFI node %(node)s; relying on UEFI boot order '
+                      'instead.',
+                      {'device': device, 'node': task.node.uuid})
+            return
+
         manager_utils.node_set_boot_device(task, device, persistent)
 
     def validate_rescue(self, task):
@@ -1573,4 +1598,12 @@ class RedfishHttpsBoot(base.BootInterface):
                 task.node, 'driver_internal_info',
                 'redfish_uefi_http_url', http_boot_url)
             task.node.save()
+
+        if _skip_lenovo_uefi_disk_boot_device(task, device):
+            LOG.debug('Skipping setting boot device to %(device)s for Lenovo '
+                      'UEFI node %(node)s; relying on UEFI boot order '
+                      'instead.',
+                      {'device': device, 'node': task.node.uuid})
+            return
+
         manager_utils.node_set_boot_device(task, device, persistent)

--- a/ironic/tests/unit/drivers/modules/redfish/test_boot.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_boot.py
@@ -1413,6 +1413,37 @@ class RedfishVirtualMediaBootTestCase(db_base.DbTestCase):
         self.node.save()
         self._test_prepare_instance_local_boot()
 
+    @mock.patch.object(boot_mode_utils, 'configure_secure_boot_if_needed',
+                       autospec=True)
+    @mock.patch.object(boot_mode_utils, 'sync_boot_mode', autospec=True)
+    @mock.patch.object(redfish_boot, '_eject_vmedia', autospec=True)
+    @mock.patch.object(image_utils, 'cleanup_iso_image', autospec=True)
+    @mock.patch.object(redfish_boot, 'manager_utils', autospec=True)
+    @mock.patch.object(redfish_utils, 'get_system', autospec=True)
+    def test_prepare_instance_local_boot_lenovo_uefi(
+            self, mock_system, mock_manager_utils,
+            mock_cleanup_iso_image, mock__eject_vmedia, mock_sync_boot_mode,
+            mock_secure_boot):
+        props = self.node.properties
+        props['vendor'] = 'Lenovo'
+        props['capabilities'] = 'boot_mode:uefi'
+        self.node.properties = props
+        self.node.driver_internal_info = {'is_whole_disk_image': True}
+        self.node.save()
+
+        with task_manager.acquire(self.context, self.node.uuid,
+                                  shared=True) as task:
+            task.node.provision_state = states.DEPLOYING
+            task.driver.boot.prepare_instance(task)
+
+            mock_manager_utils.node_set_boot_device.assert_not_called()
+            mock_cleanup_iso_image.assert_called_once_with(task)
+            mock__eject_vmedia.assert_called_once_with(
+                task, mock_system.return_value.managers,
+                sushy.VIRTUAL_MEDIA_CD)
+            mock_sync_boot_mode.assert_called_once_with(task)
+            mock_secure_boot.assert_called_once_with(task)
+
     @mock.patch.object(boot_mode_utils, 'deconfigure_secure_boot_if_needed',
                        autospec=True)
     @mock.patch.object(redfish_boot, '_eject_vmedia', autospec=True)
@@ -3093,6 +3124,31 @@ class RedfishHTTPBootTestCase(db_base.DbTestCase):
         self.node.instance_info = instance_info
         self.node.save()
         self._test_prepare_instance_local_boot()
+
+    @mock.patch.object(boot_mode_utils, 'configure_secure_boot_if_needed',
+                       autospec=True)
+    @mock.patch.object(boot_mode_utils, 'sync_boot_mode', autospec=True)
+    @mock.patch.object(image_utils, 'cleanup_iso_image', autospec=True)
+    @mock.patch.object(redfish_boot, 'manager_utils', autospec=True)
+    def test_prepare_instance_local_boot_lenovo_uefi(
+            self, mock_manager_utils, mock_cleanup_iso_image,
+            mock_sync_boot_mode, mock_secure_boot):
+        props = self.node.properties
+        props['vendor'] = 'Lenovo'
+        props['capabilities'] = 'boot_mode:uefi'
+        self.node.properties = props
+        self.node.driver_internal_info = {'is_whole_disk_image': True}
+        self.node.save()
+
+        with task_manager.acquire(self.context, self.node.uuid,
+                                  shared=True) as task:
+            task.node.provision_state = states.DEPLOYING
+            task.driver.boot.prepare_instance(task)
+
+            mock_manager_utils.node_set_boot_device.assert_not_called()
+            mock_cleanup_iso_image.assert_called_once_with(task)
+            mock_sync_boot_mode.assert_called_once_with(task)
+            mock_secure_boot.assert_called_once_with(task)
 
     @mock.patch.object(boot_mode_utils, 'deconfigure_secure_boot_if_needed',
                        autospec=True)

--- a/ironic/tests/unit/drivers/modules/test_agent.py
+++ b/ironic/tests/unit/drivers/modules/test_agent.py
@@ -1569,7 +1569,7 @@ class TestAgentDeploy(CommonTestsMixin, db_base.DbTestCase):
 
     @mock.patch.object(deploy_utils, 'destroy_images', autospec=True)
     @mock.patch.object(agent.LOG, 'warning', spec_set=True, autospec=True)
-    @mock.patch.object(manager_utils, 'node_set_boot_device', autospec=True)
+    @mock.patch.object(agent, 'set_boot_to_disk', autospec=True)
     @mock.patch.object(agent_client.AgentClient, 'get_partition_uuids',
                        autospec=True)
     @mock.patch.object(agent.AgentDeploy, 'prepare_instance_to_boot',
@@ -1591,7 +1591,7 @@ class TestAgentDeploy(CommonTestsMixin, db_base.DbTestCase):
                              task.node.driver_internal_info)
             self.assertFalse(log_mock.called)
             self.assertFalse(prepare_instance_mock.called)
-            bootdev_mock.assert_called_once_with(task, 'disk', persistent=True)
+            bootdev_mock.assert_called_once_with(task)
             self.assertEqual(states.DEPLOYING, task.node.provision_state)
             self.assertEqual(states.ACTIVE, task.node.target_provision_state)
 

--- a/releasenotes/notes/redfish-lenovo-uefi-disk-boot-loop-a7c3e1f92b4d8610.yaml
+++ b/releasenotes/notes/redfish-lenovo-uefi-disk-boot-loop-a7c3e1f92b4d8610.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixes infinite boot loops on some Lenovo UEFI systems when using the
+    Redfish virtual media boot interface. After deployment, Ironic was still
+    setting the boot device to generic HDD via Redfish, which can bypass the
+    OS UEFI shim bootloader. The Redfish boot interface now skips setting
+    the disk boot device on Lenovo UEFI nodes during deployment, matching
+    the existing PXE and agent deploy behavior from
+    `bug 2053064 <https://bugs.launchpad.net/ironic/+bug/2053064>`_.


### PR DESCRIPTION
## Summary
- Skip setting the disk boot device on Lenovo UEFI nodes in the Redfish boot interface during deployment, matching the existing PXE and agent deploy behavior for bug #2053064
- Route the agent deploy `manage_agent_boot=False` path through `set_boot_to_disk()` so `force_persistent_boot_device` is honored

## Problem
After RHCOS deployment, Ironic sets `BootSourceOverrideTarget=Hdd` with `BootSourceOverrideEnabled=Continuous` via Redfish. On some Lenovo UEFI firmware (e.g. SR645 V3 with older XCC), `Hdd` maps to the generic Hard Disk UEFI entry instead of the OS shim bootloader, causing infinite boot loops.

The PXE and agent deploy paths already skip setting disk boot on Lenovo UEFI nodes, but the Redfish boot interface did not — which is the path used by OpenShift/Metal3 Redfish provisioning.

## Test plan
- [x] `RedfishVirtualMediaBootTestCase.test_prepare_instance_local_boot_lenovo_uefi`
- [x] `RedfishHTTPBootTestCase.test_prepare_instance_local_boot_lenovo_uefi`
- [x] `TestAgentDeploy.test_prepare_instance_boot_no_manage_agent_boot`